### PR TITLE
Fix link's options representation to be compatible with read function

### DIFF
--- a/hiku/query.py
+++ b/hiku/query.py
@@ -6,7 +6,7 @@ def _name_repr(name, options):
     if options is None:
         return ':{}'.format(name)
     else:
-        return '(:{} {})'.format(name, ' '.join((':{} {!r}'.format(k, v)
+        return '(:{} {{{}}})'.format(name, ' '.join((':{} {!r}'.format(k, v)
                                                  for k, v in options.items())))
 
 


### PR DESCRIPTION
Since EDN query parser expects link's options to be a map, repr function
should return appropriate string representation of the query.