### PR TITLE
[#30] Fix invalid query validation process for nested records

### DIFF
--- a/hiku/validate/query.py
+++ b/hiku/validate/query.py
@@ -38,7 +38,8 @@ class _AssumeRecord(AbstractTypeVisitor):
             return _AssumeRecord(_nested=True).visit(obj.__item_type__)
 
     def visit_record(self, obj):
-        return list(obj.__field_types__)
+        # return fields alongside type definitions
+        return obj.__field_types__
 
 
 class _AssumeField(GraphVisitor):
@@ -198,18 +199,28 @@ class _ValidateOptions(GraphVisitor):
 
 class _RecordFieldsValidator(QueryVisitor):
 
-    def __init__(self, field_names, errors):
-        self._field_names = set(field_names)
+    def __init__(self, fields, errors):
+        self._fields = fields
         self._errors = errors
 
     def visit_field(self, obj):
-        if obj.name not in self._field_names:
+        if obj.name not in self._fields:
             self._errors.report('Unknown field name')
         elif obj.options is not None:
             self._errors.report('Options are not expected')
+        elif _AssumeRecord().visit(self._fields[obj.name]):
+            self._errors.report('Trying to query "{}" link as it was a field'
+                                .format(obj.name))
 
     def visit_link(self, obj):
-        self._errors.report('Not a link')
+        field_types = _AssumeRecord().visit(self._fields[obj.name])
+        if field_types is not None:
+            fields_validator = _RecordFieldsValidator(field_types,
+                                                      self._errors)
+            for field in obj.node.fields:
+                fields_validator.visit(field)
+        else:
+            self._errors.report('"{}" is not a link'.format(obj.name))
 
     def visit_node(self, obj):
         raise AssertionError('Node is not expected here')

--- a/hiku/validate/query.py
+++ b/hiku/validate/query.py
@@ -199,21 +199,21 @@ class _ValidateOptions(GraphVisitor):
 
 class _RecordFieldsValidator(QueryVisitor):
 
-    def __init__(self, fields, errors):
-        self._fields = fields
+    def __init__(self, field_types, errors):
+        self._field_types = field_types
         self._errors = errors
 
     def visit_field(self, obj):
-        if obj.name not in self._fields:
+        if obj.name not in self._field_types:
             self._errors.report('Unknown field name')
         elif obj.options is not None:
             self._errors.report('Options are not expected')
-        elif _AssumeRecord().visit(self._fields[obj.name]):
+        elif _AssumeRecord().visit(self._field_types[obj.name]):
             self._errors.report('Trying to query "{}" link as it was a field'
                                 .format(obj.name))
 
     def visit_link(self, obj):
-        field_types = _AssumeRecord().visit(self._fields[obj.name])
+        field_types = _AssumeRecord().visit(self._field_types[obj.name])
         if field_types is not None:
             fields_validator = _RecordFieldsValidator(field_types,
                                                       self._errors)

--- a/tests/test_validate_query.py
+++ b/tests/test_validate_query.py
@@ -28,6 +28,10 @@ GRAPH = Graph([
         Field('wounded', Optional[Record[{'attr': Integer}]], _),
         Field('annuals', Record[{'attr': Integer}], _),
         Field('hialeah', Sequence[Record[{'attr': Integer}]], _),
+
+        # nested records
+        Field('rlyeh', Record[{'cthulhu': Record[{'fhtagn': Integer}]}], _),
+
         # with options
         Field('motown', None, _, options=[Option('prine', None)]),
         Field('nyerere', None, _, options=[Option('epaule', None, default=1)]),
@@ -90,6 +94,23 @@ def test_field_complex(field_name):
         'Unknown field name',
     ])
     check_errors(q.Node([q.Link(field_name, q.Node([q.Field('attr')]))]), [])
+
+
+def test_nested_records():
+    query = q.Node([q.Link('rlyeh', q.Node([
+        q.Link('cthulhu', q.Node([q.Field('fhtagn')]))
+    ]))])
+    check_errors(query, [])
+
+    query = q.Node([q.Link('rlyeh', q.Node([q.Field('cthulhu')]))])
+    check_errors(query, ['Trying to query "cthulhu" link as it was a field'])
+
+    query = q.Node([q.Link('rlyeh', q.Node([
+        q.Link('cthulhu', q.Node([
+            q.Link('fhtagn', q.Node([q.Field('error')]))
+        ]))
+    ]))])
+    check_errors(query, ['"fhtagn" is not a link'])
 
 
 def test_non_field():


### PR DESCRIPTION
Rewrite `_RecordFieldsValidator` a littile to handle records with consideration of nested records. This fixes invalid query validation where links to nested records were not followed, and were required to be just fields.

Closes #30