### PR TITLE
Fix query merger fragment type handling for nested abstract selections

### DIFF
--- a/hiku/engine.py
+++ b/hiku/engine.py
@@ -127,6 +127,19 @@ class InitOptions(QueryTransformer):
             if type_ is not None:
                 self._path.pop()
 
+    def _resolve_fragment_type(self, type_name: str | None) -> Any | None:
+        if type_name is None:
+            return None
+        if type_name in ("Query", "Mutation"):
+            return self._graph.root
+        if type_name in self._graph.nodes_map:
+            return self._graph.nodes_map[type_name]
+        if type_name in self._graph.interfaces_map:
+            return self._graph.interfaces_map[type_name]
+        if type_name in self._graph.unions_map:
+            return self._graph.unions_map[type_name]
+        raise KeyError(type_name)
+
     def visit_node(self, obj: QueryNode) -> QueryNode:
         # Copy-on-write: fields/fragments stay None until a child actually
         # changes, then we bulk-copy prior items and append the rest.
@@ -141,7 +154,7 @@ class InitOptions(QueryTransformer):
 
         fragments: list[Fragment] | None = None
         for idx, fr in enumerate(obj.fragments):
-            with self.enter_path(self._graph.nodes_map[fr.type_name]):
+            with self.enter_path(self._resolve_fragment_type(fr.type_name)):
                 item = self.visit(fr)
             if fragments is not None:
                 fragments.append(item)

--- a/hiku/export/graphql.py
+++ b/hiku/export/graphql.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import Any
 
 from graphql.language import ast
@@ -5,10 +6,10 @@ from graphql.language import ast
 from hiku.query import Fragment
 
 from ..query import (
-    QueryVisitor,
     Field,
-    Node,
     Link,
+    Node,
+    QueryVisitor,
 )
 
 
@@ -41,6 +42,9 @@ def _encode(value: Any) -> ast.ValueNode:
 
 
 class Exporter(QueryVisitor):
+    def visit(self, obj: Any) -> Any:
+        return obj.accept(self)
+
     def visit_field(self, obj: Field) -> ast.FieldNode:
         arguments = None
         if obj.options:
@@ -94,12 +98,55 @@ class Exporter(QueryVisitor):
         return ast.SelectionSetNode(selections=selections)
 
 
+class FragmentsCollector(QueryVisitor):
+    def __init__(self) -> None:
+        self.fragments: OrderedDict[str, Fragment] = OrderedDict()
+
+    def collect(self, obj: Node) -> list[Fragment]:
+        self.visit(obj)
+        return list(self.fragments.values())
+
+    def visit_node(self, obj: Node) -> None:
+        for field in obj.fields:
+            self.visit(field)
+
+        for fragment in obj.fragments:
+            self.visit(fragment)
+
+    def visit_field(self, obj: Field) -> None:
+        return None
+
+    def visit_link(self, obj: Link) -> None:
+        self.visit(obj.node)
+
+    def visit_fragment(self, obj: Fragment) -> None:
+        if obj.name is not None:
+            if obj.name in self.fragments:
+                return
+            self.fragments[obj.name] = obj
+
+        self.visit(obj.node)
+
+
 def export(query: Node) -> ast.DocumentNode:
+    exporter = Exporter()
+    fragments = FragmentsCollector().collect(query)
+
     return ast.DocumentNode(
         definitions=[
             ast.OperationDefinitionNode(
                 operation=ast.OperationType.QUERY,
-                selection_set=Exporter().visit(query),
+                selection_set=exporter.visit(query),
             )
+        ]
+        + [
+            ast.FragmentDefinitionNode(
+                name=_name(fragment.name),
+                type_condition=ast.NamedTypeNode(
+                    name=_name(fragment.type_name),
+                ),
+                selection_set=exporter.visit(fragment.node),
+            )
+            for fragment in fragments
         ]
     )

--- a/hiku/merge.py
+++ b/hiku/merge.py
@@ -8,6 +8,7 @@ from hiku.directives import Directive
 from hiku.graph import Graph, Interface
 from hiku.query import FieldOrLink, Link, Field, Fragment, Node, QueryVisitor
 from hiku.types import (
+    InterfaceRef,
     InterfaceRefMeta,
     OptionalMeta,
     Record,
@@ -15,8 +16,10 @@ from hiku.types import (
     RefMeta,
     RefMetaTypes,
     SequenceMeta,
+    TypeRef,
     TypeRefMeta,
     Types,
+    UnionRef,
     UnionRefMeta,
     get_type,
 )
@@ -91,8 +94,40 @@ class QueryMerger(QueryVisitor):
         ref_type = get_ref_type(self._types, self._type[-1], obj.name)
 
         self._type.append(ref_type)
-        yield
-        self._type.pop()
+        try:
+            yield
+        finally:
+            self._type.pop()
+
+    @contextmanager
+    def _with_fragment_type(self, fragment: Fragment) -> t.Iterator[None]:
+        type_ = self._resolve_fragment_type(fragment.type_name)
+        if type_ is None:
+            yield
+            return
+
+        self._type.append(type_)
+        try:
+            yield
+        finally:
+            self._type.pop()
+
+    def _resolve_fragment_type(
+        self, type_name: str | None
+    ) -> type[Record] | RefMetaTypes | None:
+        if type_name is None:
+            return None
+        if type_name in ("Query", "Mutation"):
+            return self._types["__root__"]
+        if type_name in self.graph.nodes_map:
+            return TypeRef[type_name]
+        if type_name in self.graph.interfaces_map:
+            return InterfaceRef[type_name]
+        if type_name in self.graph.unions_map:
+            return UnionRef[type_name]
+        if type_name in self._types:
+            return self._types[type_name]
+        return None
 
     def visit_node(self, node: Node) -> Node:
         return self._merge_nodes([node])
@@ -210,9 +245,10 @@ class QueryMerger(QueryVisitor):
             fragments.append(self._merge_same_type_fragments(frs))
 
     def _merge_same_type_fragments(self, fragments: list[Fragment]) -> Fragment:
-        return fragments[0].copy(
-            node=self._merge_nodes([fr.node for fr in fragments]),
-        )
+        fragment = fragments[0]
+        with self._with_fragment_type(fragment):
+            node = self._merge_nodes([fr.node for fr in fragments])
+        return fragment.copy(node=node)
 
     def _expand_fragment(
         self,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -133,6 +133,212 @@ def test_init_options_returns_same_query_with_fragment_without_options():
     )
 
 
+def test_init_options_supports_interface_typed_fragment():
+    graph = Graph(
+        [
+            Node(
+                "Audio",
+                [
+                    Field("id", Integer, Mock()),
+                ],
+                implements=["Media"],
+            ),
+            Root(
+                [
+                    Link(
+                        "media",
+                        InterfaceRef["Media"],
+                        lambda: (1, TypeRef["Audio"]),
+                        requires=None,
+                    ),
+                ]
+            ),
+        ],
+        interfaces=[
+            Interface(
+                "Media",
+                [Field("id", Integer, Mock())],
+            ),
+        ],
+    )
+    query = q.Node(
+        [
+            q.Link(
+                "media",
+                q.Node(
+                    [],
+                    [
+                        q.Fragment(
+                            "MediaFields",
+                            "Media",
+                            q.Node([q.Field("id")]),
+                        )
+                    ],
+                ),
+            ),
+        ]
+    )
+
+    transformed = InitOptions(graph).visit(query)
+
+    assert transformed is query
+
+
+def test_init_options_supports_named_union_fragment_after_query_merge():
+    graph = Graph(
+        [
+            Node(
+                "SimpleContext",
+                [
+                    Field("maybeCompanyId", String, Mock()),
+                    Field("maybeOrderId", String, Mock()),
+                ],
+            ),
+            Node(
+                "SimpleAction",
+                [
+                    Field("id", Integer, Mock()),
+                    Field("title", String, Mock()),
+                ],
+            ),
+            Node(
+                "ChooseOrderAction",
+                [
+                    Field("id", Integer, Mock()),
+                    Field("title", String, Mock()),
+                ],
+            ),
+            Node(
+                "ChatNode",
+                [
+                    Link(
+                        "actions",
+                        Sequence[UnionRef["ChatBotAction"]],
+                        Mock(),
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "ChooseOrdersUpdate",
+                [
+                    Link(
+                        "node",
+                        TypeRef["ChatNode"],
+                        Mock(),
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "ContactOperatorUpdate",
+                [
+                    Link(
+                        "context",
+                        TypeRef["SimpleContext"],
+                        Mock(),
+                        requires=None,
+                    ),
+                    Link(
+                        "node",
+                        TypeRef["ChatNode"],
+                        Mock(),
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "ChatHistory",
+                [
+                    Link(
+                        "lastUpdate",
+                        Optional[UnionRef["ChatBotUpdate"]],
+                        Mock(),
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "SupportChat",
+                [
+                    Link(
+                        "history",
+                        TypeRef["ChatHistory"],
+                        Mock(),
+                        requires=None,
+                    ),
+                ],
+            ),
+            Root(
+                [
+                    Link(
+                        "supportChat",
+                        TypeRef["SupportChat"],
+                        Mock(),
+                        requires=None,
+                    ),
+                ]
+            ),
+        ],
+        unions=[
+            Union(
+                "ChatBotAction",
+                [
+                    "SimpleAction",
+                    "ChooseOrderAction",
+                ],
+            ),
+            Union(
+                "ChatBotUpdate",
+                ["ChooseOrdersUpdate", "ContactOperatorUpdate"],
+            ),
+        ],
+    )
+    src = """
+    query ChatHistoryQuery__uaprom__0(
+      $ticketCommentAfterCursor: String! = ""
+      $ticketCommentPerPage: Int! = 0
+    ) {
+      supportChat {
+        history {
+          lastUpdate {
+            __typename
+            ... on ChooseOrdersUpdate {
+              node {
+                ...l
+              }
+            }
+            ... on ContactOperatorUpdate {
+              context {
+                ...b
+              }
+              node {
+                ...l
+              }
+            }
+          }
+        }
+      }
+    }
+
+    fragment b on SimpleContext { maybeCompanyId maybeOrderId }
+    fragment c on SimpleAction { id title }
+    fragment d on ChooseOrderAction { id title }
+    fragment k on ChatBotAction { __typename ...c ...d }
+    fragment l on ChatNode {
+      __typename
+      actions {
+        ...k
+      }
+    }
+    """
+    query = QueryMerger(graph).merge(read(src))
+
+    transformed = InitOptions(graph).visit(query)
+
+    assert transformed is query
+
+
 def test_init_options_copies_field_when_options_are_normalized():
     graph = Graph(
         [

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -188,17 +188,17 @@ def test_init_options_supports_named_union_fragment():
     graph = Graph(
         [
             Node(
-                "SimpleAction",
+                "PlayTrackAction",
                 [
                     Field("id", Integer, Mock()),
                 ],
             ),
             Node(
-                "ChatNode",
+                "PlaylistEntry",
                 [
                     Link(
                         "actions",
-                        Sequence[UnionRef["ChatBotAction"]],
+                        Sequence[UnionRef["PlaylistAction"]],
                         Mock(),
                         requires=None,
                     ),
@@ -207,8 +207,8 @@ def test_init_options_supports_named_union_fragment():
             Root(
                 [
                     Link(
-                        "chat",
-                        TypeRef["ChatNode"],
+                        "playlistEntry",
+                        TypeRef["PlaylistEntry"],
                         Mock(),
                         requires=None,
                     ),
@@ -217,9 +217,9 @@ def test_init_options_supports_named_union_fragment():
         ],
         unions=[
             Union(
-                "ChatBotAction",
+                "PlaylistAction",
                 [
-                    "SimpleAction",
+                    "PlayTrackAction",
                 ],
             ),
         ],
@@ -227,7 +227,7 @@ def test_init_options_supports_named_union_fragment():
     query = q.Node(
         [
             q.Link(
-                "chat",
+                "playlistEntry",
                 q.Node(
                     [
                         q.Link(
@@ -237,7 +237,7 @@ def test_init_options_supports_named_union_fragment():
                                 [
                                     q.Fragment(
                                         "ActionFields",
-                                        "ChatBotAction",
+                                        "PlaylistAction",
                                         q.Node([q.Field("__typename")]),
                                     )
                                 ],
@@ -258,82 +258,71 @@ def test_init_options_supports_named_union_fragment_after_query_merge():
     graph = Graph(
         [
             Node(
-                "SimpleContext",
+                "PlaylistContext",
                 [
-                    Field("maybeCompanyId", String, Mock()),
-                    Field("maybeOrderId", String, Mock()),
+                    Field("artistId", String, Mock()),
+                    Field("albumId", String, Mock()),
                 ],
             ),
             Node(
-                "SimpleAction",
-                [
-                    Field("id", Integer, Mock()),
-                    Field("title", String, Mock()),
-                ],
-            ),
-            Node(
-                "ChooseOrderAction",
+                "PlayTrackAction",
                 [
                     Field("id", Integer, Mock()),
                     Field("title", String, Mock()),
                 ],
             ),
             Node(
-                "ChatNode",
+                "ChooseTrackAction",
+                [
+                    Field("id", Integer, Mock()),
+                    Field("title", String, Mock()),
+                ],
+            ),
+            Node(
+                "PlaylistEntry",
                 [
                     Link(
                         "actions",
-                        Sequence[UnionRef["ChatBotAction"]],
+                        Sequence[UnionRef["PlaylistAction"]],
                         Mock(),
                         requires=None,
                     ),
                 ],
             ),
             Node(
-                "ChooseOrdersUpdate",
+                "ChooseTracksUpdate",
                 [
                     Link(
                         "node",
-                        TypeRef["ChatNode"],
+                        TypeRef["PlaylistEntry"],
                         Mock(),
                         requires=None,
                     ),
                 ],
             ),
             Node(
-                "ContactOperatorUpdate",
+                "ContactCuratorUpdate",
                 [
                     Link(
                         "context",
-                        TypeRef["SimpleContext"],
+                        TypeRef["PlaylistContext"],
                         Mock(),
                         requires=None,
                     ),
                     Link(
                         "node",
-                        TypeRef["ChatNode"],
+                        TypeRef["PlaylistEntry"],
                         Mock(),
                         requires=None,
                     ),
                 ],
             ),
             Node(
-                "ChatHistory",
+                "PlaylistGuide",
                 [
                     Link(
                         "lastUpdate",
-                        Optional[UnionRef["ChatBotUpdate"]],
-                        Mock(),
-                        requires=None,
-                    ),
-                ],
-            ),
-            Node(
-                "SupportChat",
-                [
-                    Link(
-                        "history",
-                        TypeRef["ChatHistory"],
+                        Optional[UnionRef["PlaylistUpdate"]],
                         Mock(),
                         requires=None,
                     ),
@@ -342,8 +331,8 @@ def test_init_options_supports_named_union_fragment_after_query_merge():
             Root(
                 [
                     Link(
-                        "supportChat",
-                        TypeRef["SupportChat"],
+                        "playlistGuide",
+                        TypeRef["PlaylistGuide"],
                         Mock(),
                         requires=None,
                     ),
@@ -352,50 +341,45 @@ def test_init_options_supports_named_union_fragment_after_query_merge():
         ],
         unions=[
             Union(
-                "ChatBotAction",
+                "PlaylistAction",
                 [
-                    "SimpleAction",
-                    "ChooseOrderAction",
+                    "PlayTrackAction",
+                    "ChooseTrackAction",
                 ],
             ),
             Union(
-                "ChatBotUpdate",
-                ["ChooseOrdersUpdate", "ContactOperatorUpdate"],
+                "PlaylistUpdate",
+                ["ChooseTracksUpdate", "ContactCuratorUpdate"],
             ),
         ],
     )
     src = """
-    query ChatHistoryQuery__uaprom__0(
-      $ticketCommentAfterCursor: String! = ""
-      $ticketCommentPerPage: Int! = 0
-    ) {
-      supportChat {
-        history {
-          lastUpdate {
-            __typename
-            ... on ChooseOrdersUpdate {
-              node {
-                ...l
-              }
+    query PlaylistUpdateQuery__router__0 {
+      playlistGuide {
+        lastUpdate {
+          __typename
+          ... on ChooseTracksUpdate {
+            node {
+              ...l
             }
-            ... on ContactOperatorUpdate {
-              context {
-                ...b
-              }
-              node {
-                ...l
-              }
+          }
+          ... on ContactCuratorUpdate {
+            context {
+              ...b
+            }
+            node {
+              ...l
             }
           }
         }
       }
     }
 
-    fragment b on SimpleContext { maybeCompanyId maybeOrderId }
-    fragment c on SimpleAction { id title }
-    fragment d on ChooseOrderAction { id title }
-    fragment k on ChatBotAction { __typename ...c ...d }
-    fragment l on ChatNode {
+    fragment b on PlaylistContext { artistId albumId }
+    fragment c on PlayTrackAction { id title }
+    fragment d on ChooseTrackAction { id title }
+    fragment k on PlaylistAction { __typename ...c ...d }
+    fragment l on PlaylistEntry {
       __typename
       actions {
         ...k

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -184,6 +184,76 @@ def test_init_options_supports_interface_typed_fragment():
     assert transformed is query
 
 
+def test_init_options_supports_named_union_fragment():
+    graph = Graph(
+        [
+            Node(
+                "SimpleAction",
+                [
+                    Field("id", Integer, Mock()),
+                ],
+            ),
+            Node(
+                "ChatNode",
+                [
+                    Link(
+                        "actions",
+                        Sequence[UnionRef["ChatBotAction"]],
+                        Mock(),
+                        requires=None,
+                    ),
+                ],
+            ),
+            Root(
+                [
+                    Link(
+                        "chat",
+                        TypeRef["ChatNode"],
+                        Mock(),
+                        requires=None,
+                    ),
+                ]
+            ),
+        ],
+        unions=[
+            Union(
+                "ChatBotAction",
+                [
+                    "SimpleAction",
+                ],
+            ),
+        ],
+    )
+    query = q.Node(
+        [
+            q.Link(
+                "chat",
+                q.Node(
+                    [
+                        q.Link(
+                            "actions",
+                            q.Node(
+                                [],
+                                [
+                                    q.Fragment(
+                                        "ActionFields",
+                                        "ChatBotAction",
+                                        q.Node([q.Field("__typename")]),
+                                    )
+                                ],
+                            ),
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+
+    transformed = InitOptions(graph).visit(query)
+
+    assert transformed is query
+
+
 def test_init_options_supports_named_union_fragment_after_query_merge():
     graph = Graph(
         [

--- a/tests/test_export_graphql.py
+++ b/tests/test_export_graphql.py
@@ -1,6 +1,6 @@
 from graphql.language.printer import print_ast
 
-from hiku.query import Field, Link, Node
+from hiku.query import Field, Fragment, Link, Node
 from hiku.export.graphql import export
 
 
@@ -23,4 +23,34 @@ def test_options():
     check_export(
         Node([Field("foo", options={"bar": [1, {"baz": 2}, 3]})]),
         "{\n  foo(bar: [1, {baz: 2}, 3])\n}",
+    )
+
+
+def test_named_fragments():
+    check_export(
+        Node(
+            [],
+            [
+                Fragment(
+                    "Foo",
+                    "Bar",
+                    Node(
+                        [Field("id")],
+                        [Fragment("Baz", "Qux", Node([Field("name")]))],
+                    ),
+                ),
+            ],
+        ),
+        (
+            "{\n"
+            "  ...Foo\n"
+            "}\n\n"
+            "fragment Foo on Bar {\n"
+            "  id\n"
+            "  ...Baz\n"
+            "}\n\n"
+            "fragment Baz on Qux {\n"
+            "  name\n"
+            "}"
+        ),
     )

--- a/tests/test_query_merger.py
+++ b/tests/test_query_merger.py
@@ -1,90 +1,108 @@
 import pytest
-
 from graphql import print_ast
 from graphql.language.parser import parse
-from hiku.export.graphql import export
 
+from hiku.export.graphql import export
 from hiku.graph import Field, Graph, Interface, Link, Node, Option, Root, Union
 from hiku.merge import QueryMerger
-from hiku.types import Boolean, Integer, InterfaceRef, Optional, String, TypeRef, UnionRef, Sequence
 from hiku.readers.graphql import read
+from hiku.types import (
+    Boolean,
+    Integer,
+    InterfaceRef,
+    Optional,
+    Sequence,
+    String,
+    TypeRef,
+    UnionRef,
+)
 
 
-def mock_resolve():
-    ...
+def mock_resolve(): ...
 
 
 GRAPH = Graph(
-        [
-            Node(
-                "User",
-                [
-                    Field("id", String, mock_resolve),
-                    Field("name", String, mock_resolve, options=[
-                        Option("capitalize", Optional[Boolean], default=False)
-                    ]),
-                    Link("info", TypeRef["Info"], mock_resolve, requires=None),
-                    Link('playlist', Sequence[InterfaceRef['Media']], mock_resolve, requires=None)
-                ],
-            ),
-            Node(
-                "Info",
-                [
-                    Field("email", String, mock_resolve),
-                    Field("phone", String, mock_resolve),
-                    Link("transport", Optional[UnionRef["Transport"]], mock_resolve, requires=None)
-                ],
-            ),
-            Node(
-                "Context",
-                [
-                    Link("user", TypeRef["User"], mock_resolve, requires=None)
-                ],
-            ),
-            Node(
-                "Audio",
-                [
-                    Field("format", String, mock_resolve),
-                ],
-                implements=["Media"],
-            ),
-            Node(
-                "Video",
-                [
-                    Field("codec", String, mock_resolve),
-                ],
-                implements=["Media"],
-            ),
-            Node(
-                "Car",
-                [
-                    Field("model", String, mock_resolve),
-                    Field("year", String, mock_resolve),
-                ],
-            ),
-            Node(
-                "Bike",
-                [
-                    Field("model", String, mock_resolve),
-                ],
-            ),
-            Root(
-                [Link("context", TypeRef["Context"], mock_resolve, requires=None)]
-            ),
-        ],
-        interfaces=[
-            Interface(
-                "Media",
-                [Field("duration", Integer, mock_resolve)],
-            )
-        ],
-        unions=[Union("Transport", ["Car", "Bike"])],
-    )
+    [
+        Node(
+            "User",
+            [
+                Field("id", String, mock_resolve),
+                Field(
+                    "name",
+                    String,
+                    mock_resolve,
+                    options=[Option("capitalize", Optional[Boolean], default=False)],
+                ),
+                Link("info", TypeRef["Info"], mock_resolve, requires=None),
+                Link(
+                    "playlist",
+                    Sequence[InterfaceRef["Media"]],
+                    mock_resolve,
+                    requires=None,
+                ),
+            ],
+        ),
+        Node(
+            "Info",
+            [
+                Field("email", String, mock_resolve),
+                Field("phone", String, mock_resolve),
+                Link(
+                    "transport",
+                    Optional[UnionRef["Transport"]],
+                    mock_resolve,
+                    requires=None,
+                ),
+            ],
+        ),
+        Node(
+            "Context",
+            [Link("user", TypeRef["User"], mock_resolve, requires=None)],
+        ),
+        Node(
+            "Audio",
+            [
+                Field("format", String, mock_resolve),
+            ],
+            implements=["Media"],
+        ),
+        Node(
+            "Video",
+            [
+                Field("codec", String, mock_resolve),
+            ],
+            implements=["Media"],
+        ),
+        Node(
+            "Car",
+            [
+                Field("model", String, mock_resolve),
+                Field("year", String, mock_resolve),
+            ],
+        ),
+        Node(
+            "Bike",
+            [
+                Field("model", String, mock_resolve),
+            ],
+        ),
+        Root([Link("context", TypeRef["Context"], mock_resolve, requires=None)]),
+    ],
+    interfaces=[
+        Interface(
+            "Media",
+            [Field("duration", Integer, mock_resolve)],
+        )
+    ],
+    unions=[Union("Transport", ["Car", "Bike"])],
+)
 
 
-@pytest.mark.parametrize("src,result", [
-    pytest.param(
-        """
+@pytest.mark.parametrize(
+    "src,result",
+    [
+        pytest.param(
+            """
         query TestQuery {
             context {
                 user {
@@ -107,7 +125,7 @@ GRAPH = Graph(
             }
         }
         """,
-        """
+            """
         {
             context {
                 user {
@@ -131,10 +149,10 @@ GRAPH = Graph(
             }
         }
         """,
-        id="full query",
-    ),
-    pytest.param(
-        """
+            id="full query",
+        ),
+        pytest.param(
+            """
         query TestQuery {
             context { ...ContextFragment }
         }
@@ -149,13 +167,13 @@ GRAPH = Graph(
             user { id }
         }
         """,
-        """
+            """
         { context { user { id name } } }
         """,
-        id="only nested fragments",
-    ),
-    pytest.param(
-        """
+            id="only nested fragments",
+        ),
+        pytest.param(
+            """
         query TestQuery {
             context { user { id info { email } } ...ContextFragment }
         }
@@ -170,13 +188,13 @@ GRAPH = Graph(
             user { id info { phone } }
         }
         """,
-        """
+            """
         { context { user { id name info { email phone } } } }
         """,
-        id="fields + fragments",
-    ),
-    pytest.param(
-        """
+            id="fields + fragments",
+        ),
+        pytest.param(
+            """
         query TestQuery {
             context { user { id } ...ContextFragment }
         }
@@ -191,12 +209,13 @@ GRAPH = Graph(
             user { id capName: name(capitalize: true) }
         }
         """,
-        """
+            """
         { context { user { id name capName: name(capitalize: true) } } }
         """,
-        id="fields + aliases + fragments",
-    ),
-])
+            id="fields + aliases + fragments",
+        ),
+    ],
+)
 def test_query_merger(src, result):
     exp = print_ast(parse(result)).strip()
 
@@ -206,10 +225,354 @@ def test_query_merger(src, result):
     assert got == exp
 
 
+@pytest.mark.parametrize(
+    "src,result",
+    [
+        pytest.param(
+            """
+        query QueryMergerMy {
+            supportChat {
+                history {
+                    lastUpdate {
+                        __typename
+                        ...ChatBotUpdate
+                    }
+                }
+            }
+        }
 
-@pytest.mark.parametrize("src,result", [
-    pytest.param(
-        """
+        fragment SimpleContextFragment on SimpleContext {
+            maybeCompanyId
+            maybeOrderId
+        }
+
+        fragment ChatBotActionFragment on ChatBotAction {
+            __typename
+            ... on SimpleAction {
+                id
+                title
+            }
+            ... on ChooseOrderAction {
+                id
+                title
+            }
+        }
+
+        fragment ChatBotNodeFragment on ChatNode {
+            __typename
+            actions {
+                __typename
+                ...ChatBotActionFragment
+            }
+        }
+
+        fragment ChatBotUpdate on ChatBotUpdate {
+            __typename
+            ... on ChooseOrdersUpdate {
+                node {
+                    ...ChatBotNodeFragment
+                }
+            }
+            ... on ContactOperatorUpdate {
+                context {
+                    ...SimpleContextFragment
+                }
+                node {
+                    ...ChatBotNodeFragment
+                }
+            }
+        }
+        """,
+            """
+        {
+            supportChat {
+                history {
+                    lastUpdate {
+                        __typename
+                        ... on ChooseOrdersUpdate {
+                            node {
+                                ...ChatBotNodeFragment
+                            }
+                        }
+                        ... on ContactOperatorUpdate {
+                            context {
+                                ...SimpleContextFragment
+                            }
+                            node {
+                                ...ChatBotNodeFragment
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fragment ChatBotNodeFragment on ChatNode {
+            __typename
+            actions {
+                __typename
+                ...ChatBotActionFragment
+            }
+        }
+
+        fragment ChatBotActionFragment on ChatBotAction {
+            __typename
+            ... on SimpleAction {
+                id
+                title
+            }
+            ... on ChooseOrderAction {
+                id
+                title
+            }
+        }
+
+        fragment SimpleContextFragment on SimpleContext {
+            maybeCompanyId
+            maybeOrderId
+        }
+        """,
+            id="original-style reduced production query keeps action fragment",
+        ),
+        pytest.param(
+            """
+        query ChatHistoryQuery__uaprom__0(
+            $ticketCommentAfterCursor: String! = ""
+            $ticketCommentPerPage: Int! = 0
+        ) {
+            supportChat {
+                history {
+                    lastUpdate {
+                        __typename
+                        ... on ChooseOrdersUpdate {
+                            node {
+                                ...l
+                            }
+                        }
+                        ... on ContactOperatorUpdate {
+                            context {
+                                ...b
+                            }
+                            node {
+                                ...l
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fragment b on SimpleContext {
+            maybeCompanyId
+            maybeOrderId
+        }
+
+        fragment c on SimpleAction {
+            id
+            title
+        }
+
+        fragment d on ChooseOrderAction {
+            id
+            title
+        }
+
+        fragment k on ChatBotAction {
+            __typename
+            ...c
+            ...d
+        }
+
+        fragment l on ChatNode {
+            __typename
+            actions {
+                ...k
+            }
+        }
+        """,
+            """
+        {
+            supportChat {
+                history {
+                    lastUpdate {
+                        __typename
+                        ... on ChooseOrdersUpdate {
+                            node {
+                                ...l
+                            }
+                        }
+                        ... on ContactOperatorUpdate {
+                            context {
+                                ...b
+                            }
+                            node {
+                                ...l
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fragment l on ChatNode {
+            __typename
+            actions {
+                ...k
+            }
+        }
+
+        fragment k on ChatBotAction {
+            __typename
+            ...c
+            ...d
+        }
+
+        fragment c on SimpleAction {
+            id
+            title
+        }
+
+        fragment d on ChooseOrderAction {
+            id
+            title
+        }
+
+        fragment b on SimpleContext {
+            maybeCompanyId
+            maybeOrderId
+        }
+        """,
+            id="apollo-router-style reduced production query keeps action fragment",
+        ),
+    ],
+)
+def test_query_merger_my(src, result):
+    exp = print_ast(parse(result)).strip()
+
+    graph = Graph(
+        [
+            Node(
+                "SimpleAction",
+                [
+                    Field("id", Integer, mock_resolve),
+                    Field("title", String, mock_resolve),
+                ],
+            ),
+            Node(
+                "ChooseOrderAction",
+                [
+                    Field("id", Integer, mock_resolve),
+                    Field("title", String, mock_resolve),
+                ],
+            ),
+            Node(
+                "ChatNode",
+                [
+                    Field("__typename", String, mock_resolve),
+                    Link(
+                        "actions",
+                        Sequence[UnionRef["ChatBotAction"]],
+                        mock_resolve,
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "SimpleContext",
+                [
+                    Field("maybeCompanyId", String, mock_resolve),
+                    Field("maybeOrderId", String, mock_resolve),
+                ],
+            ),
+            Node(
+                "ChooseOrdersUpdate",
+                [
+                    Field("__typename", String, mock_resolve),
+                    Link(
+                        "node",
+                        TypeRef["ChatNode"],
+                        mock_resolve,
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "ContactOperatorUpdate",
+                [
+                    Field("__typename", String, mock_resolve),
+                    Link(
+                        "context",
+                        TypeRef["SimpleContext"],
+                        mock_resolve,
+                        requires=None,
+                    ),
+                    Link(
+                        "node",
+                        TypeRef["ChatNode"],
+                        mock_resolve,
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "ChatHistory",
+                [
+                    Link(
+                        "lastUpdate",
+                        UnionRef["ChatBotUpdate"],
+                        mock_resolve,
+                        requires=None,
+                    ),
+                ],
+            ),
+            Node(
+                "SupportChat",
+                [
+                    Link(
+                        "history",
+                        TypeRef["ChatHistory"],
+                        mock_resolve,
+                        requires=None,
+                    ),
+                ],
+            ),
+            Root(
+                [
+                    Link(
+                        "supportChat",
+                        TypeRef["SupportChat"],
+                        mock_resolve,
+                        requires=None,
+                    ),
+                ]
+            ),
+        ],
+        unions=[
+            Union(
+                "ChatBotAction",
+                [
+                    "SimpleAction",
+                    "ChooseOrderAction",
+                ],
+            ),
+            Union(
+                "ChatBotUpdate",
+                ["ChooseOrdersUpdate", "ContactOperatorUpdate"],
+            ),
+        ],
+    )
+
+    query = QueryMerger(graph).merge(read(src))
+    got = print_ast(export(query)).strip()
+
+    assert got == exp
+
+
+@pytest.mark.parametrize(
+    "src,result",
+    [
+        pytest.param(
+            """
         query TestQuery {
             context { user { info { transport {
                 ... on Car { year }
@@ -222,31 +585,32 @@ def test_query_merger(src, result):
             ... on Bike { model }
         }
         """,
-        """
+            """
         { context { user { info { transport {
             ... on Car { year model }
             ... on Bike { model }
         } } } } }
         """,
-        id="union fragments inside fragment",
-    ),
-    pytest.param(
-        """
+            id="union fragments inside fragment",
+        ),
+        pytest.param(
+            """
         query TestQuery { context { user { info { transport {
             ... on Car { year }
             ... on Car { model }
             ... on Bike { model }
         } } } } }
         """,
-        """
+            """
         { context { user { info { transport {
             ... on Car { year model }
             ... on Bike { model }
         } } } } }
         """,
-        id="union fragments flat",
-    ),
-])
+            id="union fragments flat",
+        ),
+    ],
+)
 def test_query_merger__unions(src, result):
     exp = print_ast(parse(result)).strip()
     query = read(src)
@@ -256,42 +620,44 @@ def test_query_merger__unions(src, result):
     assert got == exp
 
 
-@pytest.mark.parametrize("src,result", [
-    pytest.param(
-        """
+@pytest.mark.parametrize(
+    "src,result",
+    [
+        pytest.param(
+            """
         query TestQuery { context { user { playlist {
             ... on Audio { duration format }
             ... on Video { duration codec }
         } } } }
         """,
-        """
+            """
         { context { user { playlist {
             duration
             ... on Audio { format }
             ... on Video { codec }
         } } } }
         """,
-        id="interface fragments - fields inside fragments",
-    ),
-    pytest.param(
-        """
+            id="interface fragments - fields inside fragments",
+        ),
+        pytest.param(
+            """
         query TestQuery { context { user { playlist {
             duration
             ... on Audio { format }
             ... on Video { duration codec }
         } } } }
         """,
-        """
+            """
         { context { user { playlist {
             duration
             ... on Audio { format }
             ... on Video { codec }
         } } } }
         """,
-        id="interface fragments - fields inside and outside fragments",
-    ),
-    pytest.param(
-        """
+            id="interface fragments - fields inside and outside fragments",
+        ),
+        pytest.param(
+            """
         query TestQuery { context { user { playlist {
             ...PlaylistFragment
         } } } }
@@ -300,16 +666,17 @@ def test_query_merger__unions(src, result):
             ... on Video { duration codec }
         }
         """,
-        """
+            """
         { context { user { playlist {
             duration
             ... on Audio { format }
             ... on Video { codec }
         } } } }
         """,
-        id="interface fragments - fragments inside fragments",
-    ),
-])
+            id="interface fragments - fragments inside fragments",
+        ),
+    ],
+)
 def test_query_merger__interfaces(src, result):
     exp = print_ast(parse(result)).strip()
 

--- a/tests/test_query_merger.py
+++ b/tests/test_query_merger.py
@@ -291,48 +291,46 @@ def test_query_merger(src, result):
                         __typename
                         ... on ChooseOrdersUpdate {
                             node {
-                                ...ChatBotNodeFragment
+                                __typename
+                                actions {
+                                    __typename
+                                    ... on SimpleAction {
+                                        id
+                                        title
+                                    }
+                                    ... on ChooseOrderAction {
+                                        id
+                                        title
+                                    }
+                                }
                             }
                         }
                         ... on ContactOperatorUpdate {
                             context {
-                                ...SimpleContextFragment
+                                maybeCompanyId
+                                maybeOrderId
                             }
                             node {
-                                ...ChatBotNodeFragment
+                                __typename
+                                actions {
+                                    __typename
+                                    ... on SimpleAction {
+                                        id
+                                        title
+                                    }
+                                    ... on ChooseOrderAction {
+                                        id
+                                        title
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
         }
-
-        fragment ChatBotNodeFragment on ChatNode {
-            __typename
-            actions {
-                __typename
-                ...ChatBotActionFragment
-            }
-        }
-
-        fragment ChatBotActionFragment on ChatBotAction {
-            __typename
-            ... on SimpleAction {
-                id
-                title
-            }
-            ... on ChooseOrderAction {
-                id
-                title
-            }
-        }
-
-        fragment SimpleContextFragment on SimpleContext {
-            maybeCompanyId
-            maybeOrderId
-        }
         """,
-            id="original-style reduced production query keeps action fragment",
+            id="original-style reduced production query normalizes wrapper fragments",
         ),
         pytest.param(
             """
@@ -398,9 +396,55 @@ def test_query_merger(src, result):
                         __typename
                         ... on ChooseOrdersUpdate {
                             node {
-                                ...l
+                                __typename
+                                actions {
+                                    __typename
+                                    ...c
+                                    ...d
+                                }
                             }
                         }
+                        ... on ContactOperatorUpdate {
+                            context {
+                                maybeCompanyId
+                                maybeOrderId
+                            }
+                            node {
+                                __typename
+                                actions {
+                                    __typename
+                                    ...c
+                                    ...d
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fragment c on SimpleAction {
+            id
+            title
+        }
+
+        fragment d on ChooseOrderAction {
+            id
+            title
+        }
+        """,
+            id="apollo-router-style reduced production query normalizes wrapper fragments",
+        ),
+        pytest.param(
+            """
+        query ChatHistoryQuery__uaprom__1(
+            $ticketCommentAfterCursor: String! = ""
+            $ticketCommentPerPage: Int! = 0
+        ) {
+            supportChat {
+                history {
+                    lastUpdate {
+                        __typename
                         ... on ContactOperatorUpdate {
                             context {
                                 ...b
@@ -414,17 +458,9 @@ def test_query_merger(src, result):
             }
         }
 
-        fragment l on ChatNode {
-            __typename
-            actions {
-                ...k
-            }
-        }
-
-        fragment k on ChatBotAction {
-            __typename
-            ...c
-            ...d
+        fragment b on SimpleContext {
+            maybeCompanyId
+            maybeOrderId
         }
 
         fragment c on SimpleAction {
@@ -437,12 +473,55 @@ def test_query_merger(src, result):
             title
         }
 
-        fragment b on SimpleContext {
-            maybeCompanyId
-            maybeOrderId
+        fragment k on ChatBotAction {
+            __typename
+            ...c
+            ...d
+        }
+
+        fragment l on ChatNode {
+            __typename
+            actions {
+                ...k
+            }
         }
         """,
-            id="apollo-router-style reduced production query keeps action fragment",
+            """
+        {
+            supportChat {
+                history {
+                    lastUpdate {
+                        __typename
+                        ... on ContactOperatorUpdate {
+                            context {
+                                maybeCompanyId
+                                maybeOrderId
+                            }
+                            node {
+                                __typename
+                                actions {
+                                    __typename
+                                    ...c
+                                    ...d
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fragment c on SimpleAction {
+            id
+            title
+        }
+
+        fragment d on ChooseOrderAction {
+            id
+            title
+        }
+        """,
+            id="apollo-router-style reduced production query without chooseorders still normalizes wrapper fragments",
         ),
     ],
 )

--- a/tests/test_query_merger.py
+++ b/tests/test_query_merger.py
@@ -230,98 +230,94 @@ def test_query_merger(src, result):
     [
         pytest.param(
             """
-        query QueryMergerMy {
-            supportChat {
-                history {
-                    lastUpdate {
-                        __typename
-                        ...ChatBotUpdate
-                    }
+        query PlaylistUpdateQuery {
+            playlistGuide {
+                lastUpdate {
+                    __typename
+                    ...PlaylistUpdate
                 }
             }
         }
 
-        fragment SimpleContextFragment on SimpleContext {
-            maybeCompanyId
-            maybeOrderId
+        fragment PlaylistContextFragment on PlaylistContext {
+            artistId
+            albumId
         }
 
-        fragment ChatBotActionFragment on ChatBotAction {
+        fragment PlaylistActionFragment on PlaylistAction {
             __typename
-            ... on SimpleAction {
+            ... on PlayTrackAction {
                 id
                 title
             }
-            ... on ChooseOrderAction {
+            ... on ChooseTrackAction {
                 id
                 title
             }
         }
 
-        fragment ChatBotNodeFragment on ChatNode {
+        fragment PlaylistEntryFragment on PlaylistEntry {
             __typename
             actions {
                 __typename
-                ...ChatBotActionFragment
+                ...PlaylistActionFragment
             }
         }
 
-        fragment ChatBotUpdate on ChatBotUpdate {
+        fragment PlaylistUpdate on PlaylistUpdate {
             __typename
-            ... on ChooseOrdersUpdate {
+            ... on ChooseTracksUpdate {
                 node {
-                    ...ChatBotNodeFragment
+                    ...PlaylistEntryFragment
                 }
             }
-            ... on ContactOperatorUpdate {
+            ... on ContactCuratorUpdate {
                 context {
-                    ...SimpleContextFragment
+                    ...PlaylistContextFragment
                 }
                 node {
-                    ...ChatBotNodeFragment
+                    ...PlaylistEntryFragment
                 }
             }
         }
         """,
             """
         {
-            supportChat {
-                history {
-                    lastUpdate {
-                        __typename
-                        ... on ChooseOrdersUpdate {
-                            node {
+            playlistGuide {
+                lastUpdate {
+                    __typename
+                    ... on ChooseTracksUpdate {
+                        node {
+                            __typename
+                            actions {
                                 __typename
-                                actions {
-                                    __typename
-                                    ... on SimpleAction {
-                                        id
-                                        title
-                                    }
-                                    ... on ChooseOrderAction {
-                                        id
-                                        title
-                                    }
+                                ... on PlayTrackAction {
+                                    id
+                                    title
+                                }
+                                ... on ChooseTrackAction {
+                                    id
+                                    title
                                 }
                             }
                         }
-                        ... on ContactOperatorUpdate {
-                            context {
-                                maybeCompanyId
-                                maybeOrderId
-                            }
-                            node {
+                    }
+                    ... on ContactCuratorUpdate {
+                        context {
+                            artistId
+                            albumId
+                        }
+                        node {
+                            __typename
+                            actions {
                                 __typename
-                                actions {
-                                    __typename
-                                    ... on SimpleAction {
-                                        id
-                                        title
-                                    }
-                                    ... on ChooseOrderAction {
-                                        id
-                                        title
-                                    }
+                                ... on PlayTrackAction {
+                                    id
+                                    title
+                                }
+                                ... on ChooseTrackAction {
+                                    id
+                                    title
                                 }
                             }
                         }
@@ -330,58 +326,53 @@ def test_query_merger(src, result):
             }
         }
         """,
-            id="original-style reduced production query normalizes wrapper fragments",
+            id="original-style playlist query normalizes wrapper fragments",
         ),
         pytest.param(
             """
-        query ChatHistoryQuery__uaprom__0(
-            $ticketCommentAfterCursor: String! = ""
-            $ticketCommentPerPage: Int! = 0
-        ) {
-            supportChat {
-                history {
-                    lastUpdate {
-                        __typename
-                        ... on ChooseOrdersUpdate {
-                            node {
-                                ...l
-                            }
+        query PlaylistUpdateQuery__router__0 {
+            playlistGuide {
+                lastUpdate {
+                    __typename
+                    ... on ChooseTracksUpdate {
+                        node {
+                            ...l
                         }
-                        ... on ContactOperatorUpdate {
-                            context {
-                                ...b
-                            }
-                            node {
-                                ...l
-                            }
+                    }
+                    ... on ContactCuratorUpdate {
+                        context {
+                            ...b
+                        }
+                        node {
+                            ...l
                         }
                     }
                 }
             }
         }
 
-        fragment b on SimpleContext {
-            maybeCompanyId
-            maybeOrderId
+        fragment b on PlaylistContext {
+            artistId
+            albumId
         }
 
-        fragment c on SimpleAction {
+        fragment c on PlayTrackAction {
             id
             title
         }
 
-        fragment d on ChooseOrderAction {
+        fragment d on ChooseTrackAction {
             id
             title
         }
 
-        fragment k on ChatBotAction {
+        fragment k on PlaylistAction {
             __typename
             ...c
             ...d
         }
 
-        fragment l on ChatNode {
+        fragment l on PlaylistEntry {
             __typename
             actions {
                 ...k
@@ -390,32 +381,30 @@ def test_query_merger(src, result):
         """,
             """
         {
-            supportChat {
-                history {
-                    lastUpdate {
-                        __typename
-                        ... on ChooseOrdersUpdate {
-                            node {
+            playlistGuide {
+                lastUpdate {
+                    __typename
+                    ... on ChooseTracksUpdate {
+                        node {
+                            __typename
+                            actions {
                                 __typename
-                                actions {
-                                    __typename
-                                    ...c
-                                    ...d
-                                }
+                                ...c
+                                ...d
                             }
                         }
-                        ... on ContactOperatorUpdate {
-                            context {
-                                maybeCompanyId
-                                maybeOrderId
-                            }
-                            node {
+                    }
+                    ... on ContactCuratorUpdate {
+                        context {
+                            artistId
+                            albumId
+                        }
+                        node {
+                            __typename
+                            actions {
                                 __typename
-                                actions {
-                                    __typename
-                                    ...c
-                                    ...d
-                                }
+                                ...c
+                                ...d
                             }
                         }
                     }
@@ -423,63 +412,58 @@ def test_query_merger(src, result):
             }
         }
 
-        fragment c on SimpleAction {
+        fragment c on PlayTrackAction {
             id
             title
         }
 
-        fragment d on ChooseOrderAction {
+        fragment d on ChooseTrackAction {
             id
             title
         }
         """,
-            id="apollo-router-style reduced production query normalizes wrapper fragments",
+            id="apollo-router-style playlist query normalizes wrapper fragments",
         ),
         pytest.param(
             """
-        query ChatHistoryQuery__uaprom__1(
-            $ticketCommentAfterCursor: String! = ""
-            $ticketCommentPerPage: Int! = 0
-        ) {
-            supportChat {
-                history {
-                    lastUpdate {
-                        __typename
-                        ... on ContactOperatorUpdate {
-                            context {
-                                ...b
-                            }
-                            node {
-                                ...l
-                            }
+        query PlaylistUpdateQuery__router__1 {
+            playlistGuide {
+                lastUpdate {
+                    __typename
+                    ... on ContactCuratorUpdate {
+                        context {
+                            ...b
+                        }
+                        node {
+                            ...l
                         }
                     }
                 }
             }
         }
 
-        fragment b on SimpleContext {
-            maybeCompanyId
-            maybeOrderId
+        fragment b on PlaylistContext {
+            artistId
+            albumId
         }
 
-        fragment c on SimpleAction {
+        fragment c on PlayTrackAction {
             id
             title
         }
 
-        fragment d on ChooseOrderAction {
+        fragment d on ChooseTrackAction {
             id
             title
         }
 
-        fragment k on ChatBotAction {
+        fragment k on PlaylistAction {
             __typename
             ...c
             ...d
         }
 
-        fragment l on ChatNode {
+        fragment l on PlaylistEntry {
             __typename
             actions {
                 ...k
@@ -488,22 +472,20 @@ def test_query_merger(src, result):
         """,
             """
         {
-            supportChat {
-                history {
-                    lastUpdate {
-                        __typename
-                        ... on ContactOperatorUpdate {
-                            context {
-                                maybeCompanyId
-                                maybeOrderId
-                            }
-                            node {
+            playlistGuide {
+                lastUpdate {
+                    __typename
+                    ... on ContactCuratorUpdate {
+                        context {
+                            artistId
+                            albumId
+                        }
+                        node {
+                            __typename
+                            actions {
                                 __typename
-                                actions {
-                                    __typename
-                                    ...c
-                                    ...d
-                                }
+                                ...c
+                                ...d
                             }
                         }
                     }
@@ -511,17 +493,17 @@ def test_query_merger(src, result):
             }
         }
 
-        fragment c on SimpleAction {
+        fragment c on PlayTrackAction {
             id
             title
         }
 
-        fragment d on ChooseOrderAction {
+        fragment d on ChooseTrackAction {
             id
             title
         }
         """,
-            id="apollo-router-style reduced production query without chooseorders still normalizes wrapper fragments",
+            id="apollo-router-style playlist query without choosetracks still normalizes wrapper fragments",
         ),
     ],
 )
@@ -531,85 +513,74 @@ def test_query_merger_my(src, result):
     graph = Graph(
         [
             Node(
-                "SimpleAction",
+                "PlayTrackAction",
                 [
                     Field("id", Integer, mock_resolve),
                     Field("title", String, mock_resolve),
                 ],
             ),
             Node(
-                "ChooseOrderAction",
+                "ChooseTrackAction",
                 [
                     Field("id", Integer, mock_resolve),
                     Field("title", String, mock_resolve),
                 ],
             ),
             Node(
-                "ChatNode",
+                "PlaylistEntry",
                 [
                     Field("__typename", String, mock_resolve),
                     Link(
                         "actions",
-                        Sequence[UnionRef["ChatBotAction"]],
+                        Sequence[UnionRef["PlaylistAction"]],
                         mock_resolve,
                         requires=None,
                     ),
                 ],
             ),
             Node(
-                "SimpleContext",
+                "PlaylistContext",
                 [
-                    Field("maybeCompanyId", String, mock_resolve),
-                    Field("maybeOrderId", String, mock_resolve),
+                    Field("artistId", String, mock_resolve),
+                    Field("albumId", String, mock_resolve),
                 ],
             ),
             Node(
-                "ChooseOrdersUpdate",
+                "ChooseTracksUpdate",
                 [
                     Field("__typename", String, mock_resolve),
                     Link(
                         "node",
-                        TypeRef["ChatNode"],
+                        TypeRef["PlaylistEntry"],
                         mock_resolve,
                         requires=None,
                     ),
                 ],
             ),
             Node(
-                "ContactOperatorUpdate",
+                "ContactCuratorUpdate",
                 [
                     Field("__typename", String, mock_resolve),
                     Link(
                         "context",
-                        TypeRef["SimpleContext"],
+                        TypeRef["PlaylistContext"],
                         mock_resolve,
                         requires=None,
                     ),
                     Link(
                         "node",
-                        TypeRef["ChatNode"],
+                        TypeRef["PlaylistEntry"],
                         mock_resolve,
                         requires=None,
                     ),
                 ],
             ),
             Node(
-                "ChatHistory",
+                "PlaylistGuide",
                 [
                     Link(
                         "lastUpdate",
-                        UnionRef["ChatBotUpdate"],
-                        mock_resolve,
-                        requires=None,
-                    ),
-                ],
-            ),
-            Node(
-                "SupportChat",
-                [
-                    Link(
-                        "history",
-                        TypeRef["ChatHistory"],
+                        UnionRef["PlaylistUpdate"],
                         mock_resolve,
                         requires=None,
                     ),
@@ -618,8 +589,8 @@ def test_query_merger_my(src, result):
             Root(
                 [
                     Link(
-                        "supportChat",
-                        TypeRef["SupportChat"],
+                        "playlistGuide",
+                        TypeRef["PlaylistGuide"],
                         mock_resolve,
                         requires=None,
                     ),
@@ -628,15 +599,15 @@ def test_query_merger_my(src, result):
         ],
         unions=[
             Union(
-                "ChatBotAction",
+                "PlaylistAction",
                 [
-                    "SimpleAction",
-                    "ChooseOrderAction",
+                    "PlayTrackAction",
+                    "ChooseTrackAction",
                 ],
             ),
             Union(
-                "ChatBotUpdate",
-                ["ChooseOrdersUpdate", "ContactOperatorUpdate"],
+                "PlaylistUpdate",
+                ["ChooseTracksUpdate", "ContactCuratorUpdate"],
             ),
         ],
     )


### PR DESCRIPTION
## Summary
- fix `QueryMerger` to merge nested fragment bodies using the fragment's concrete type context
- keep `InitOptions` defensive for named union/interface fragments that remain after merge
- export named fragment definitions in GraphQL output
- add regressions for reduced Apollo-router query shapes, direct union fragments, complex-field fragments, and GraphQL export

## Testing
- `uv run pytest tests/test_query_merger.py::test_query_merger_my -vv`
- `uv run pytest tests/test_engine.py::test_init_options_supports_named_union_fragment tests/test_engine.py::test_init_options_supports_named_union_fragment_after_query_merge -vv`
- `uv run pytest tests/test_engine.py::test_merge_query__complex_field_fragment tests/test_query_merger.py::test_query_merger_my tests/test_engine.py::test_init_options_supports_named_union_fragment tests/test_engine.py::test_init_options_supports_named_union_fragment_after_query_merge -vv`