### PR TITLE
Add @specifiedBy directive support for custom scalars

### DIFF
--- a/docs/changelog/changes_08.rst
+++ b/docs/changelog/changes_08.rst
@@ -4,6 +4,9 @@ Changes in 0.8
 0.8.0rcXX
 ~~~~~~~~~
 
+- Add GraphQL ``@specifiedBy`` support for custom scalars in introspection and
+  federation SDL export.
+
 0.8.0rc28
 ~~~~~~~~~
 

--- a/docs/scalars.rst
+++ b/docs/scalars.rst
@@ -64,6 +64,21 @@ If builtin scalars do not cover your specific needs, you can define custom scala
         class YMDDate(Scalar):
             ...
 
+    You can also pass ``specified_by_url`` to expose a GraphQL
+    ``@specifiedBy`` URL for custom scalars in introspection and SDL:
+
+    .. code-block:: python
+
+        from hiku.scalar import Scalar, scalar
+
+        @scalar(
+            "UUID",
+            "The `UUID` scalar type represents a UUID.",
+            specified_by_url="https://tools.ietf.org/html/rfc4122",
+        )
+        class UUID(Scalar):
+            ...
+
 Now, lets look at the full example:
 
 .. code-block:: python
@@ -151,4 +166,3 @@ We will get this result:
         "id": "1",
         "dateCreated": "2023-06-15",
     }
-

--- a/hiku/directives/__init__.py
+++ b/hiku/directives/__init__.py
@@ -341,6 +341,19 @@ class Deprecated(SchemaDirective):
     )
 
 
+@schema_directive(
+    name="specifiedBy",
+    locations=[Location.SCALAR],
+    description=("Exposes a specification URL for a custom scalar's behavior."),
+)
+class SpecifiedBy(SchemaDirective):
+    """https://spec.graphql.org/draft/#sec--specifiedBy"""
+
+    url: str = schema_directive_field(
+        description="The custom scalar specification URL.",
+    )
+
+
 def get_deprecated(
     obj: t.Union["Field", "Link", "Option"],
 ) -> Deprecated | None:

--- a/hiku/federation/sdl.py
+++ b/hiku/federation/sdl.py
@@ -390,9 +390,26 @@ class Exporter(GraphVisitor):
                 ):  # noqa: E501
                     continue
 
+            directives = []
+            if scalar.__specified_by_url__ is not None:
+                directives = [
+                    ast.DirectiveNode(
+                        name=_name("specifiedBy"),
+                        arguments=[
+                            ast.ArgumentNode(
+                                name=_name("url"),
+                                value=ast.StringValueNode(
+                                    value=scalar.__specified_by_url__,
+                                ),
+                            )
+                        ],
+                    )
+                ]
+
             scalars.append(
                 ast.ScalarTypeDefinitionNode(
                     name=_name(scalar.__type_name__),
+                    directives=directives,
                 )
             )
         return _BUILTIN_SCALARS + scalars

--- a/hiku/introspection/graphql.py
+++ b/hiku/introspection/graphql.py
@@ -9,6 +9,7 @@ from ..directives import (
     Deprecated,
     Directive,
     SchemaDirective,
+    SpecifiedBy,
     _IncludeDirective,
     _SkipDirective,
     get_deprecated,
@@ -80,15 +81,12 @@ _BUILTIN_DIRECTIVES: tuple[type[Directive] | type[SchemaDirective], ...] = (
     _IncludeDirective,
     Deprecated,
     Cached,
+    SpecifiedBy,
 )
 
-BUILTIN_SCALARS: tuple[SCALAR, ...] = (  # type: ignore[valid-type]
-    SCALAR("String"),
-    SCALAR("Int"),
-    SCALAR("Boolean"),
-    SCALAR("Float"),
-    SCALAR("Any"),
-    SCALAR("ID"),
+BUILTIN_SCALAR_NAMES = ("String", "Int", "Boolean", "Float", "Any", "ID")
+BUILTIN_SCALARS: tuple[SCALAR, ...] = tuple(  # type: ignore[valid-type]
+    SCALAR(name) for name in BUILTIN_SCALAR_NAMES
 )
 
 
@@ -243,6 +241,8 @@ def type_link(
         )
     elif name in schema.query_graph.scalars_map:
         return SCALAR(name)
+    elif name in BUILTIN_SCALAR_NAMES:
+        return SCALAR(name)
     else:
         return Nothing
 
@@ -349,6 +349,10 @@ def type_info(
             info = {"id": ident, "kind": "LIST"}
         elif isinstance(ident, SCALAR):
             info = {"id": ident, "name": ident.name, "kind": "SCALAR"}
+            scalar = schema.query_graph.scalars_map.get(ident.name)
+            if scalar is not None:
+                info["description"] = scalar.__description__
+                info["specifiedByURL"] = scalar.__specified_by_url__
         elif isinstance(ident, UNION):
             info = {
                 "id": ident,
@@ -747,6 +751,7 @@ GRAPH = Graph(
                 Field("kind", String, type_info),
                 Field("name", String, type_info),
                 Field("description", String, type_info),
+                Field("specifiedByURL", String, type_info),
                 # OBJECT and INTERFACE only
                 Link(
                     "fields",

--- a/hiku/scalar.py
+++ b/hiku/scalar.py
@@ -7,7 +7,9 @@ if TYPE_CHECKING:
 
 
 def scalar(
-    name: str | None = None, description: str | None = None
+    name: str | None = None,
+    description: str | None = None,
+    specified_by_url: str | None = None,
 ) -> Callable[[type["Scalar"]], type["Scalar"]]:
     """
     Use @scalar decorator to set custom name and description for
@@ -20,6 +22,7 @@ def scalar(
     def _scalar(cls: type["Scalar"]) -> type["Scalar"]:
         cls.__type_name__ = name or cls.__name__
         cls.__description__ = description
+        cls.__specified_by_url__ = specified_by_url
         return cls
 
     return _scalar
@@ -32,10 +35,15 @@ class ScalarMeta(type):
 
     __type_name__: str
     __description__: str | None
+    __specified_by_url__: str | None
 
     def __new__(cls, *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
         instance = super().__new__(cls, *args, **kwargs)
         instance.__type_name__ = instance.__name__
+        if "__description__" not in instance.__dict__:
+            instance.__description__ = None
+        if "__specified_by_url__" not in instance.__dict__:
+            instance.__specified_by_url__ = None
         return instance
 
 

--- a/tests/test_federation/test_introspection_graphql.py
+++ b/tests/test_federation/test_introspection_graphql.py
@@ -63,6 +63,9 @@ def _schema(types, with_mutation=False) -> dict:
                 _directive('cached', ['FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'], [
                     _ival('ttl', _non_null(_INT), description=ANY)
                 ]),
+                _directive('specifiedBy', ['SCALAR'], [
+                    _ival('url', _non_null(_STR), description=ANY)
+                ]),
             ],
             'mutationType': {'name': 'Mutation'} if with_mutation else None,
             'queryType': {'name': 'Query'},

--- a/tests/test_federation/test_sdl_v2.py
+++ b/tests/test_federation/test_sdl_v2.py
@@ -24,7 +24,7 @@ from hiku.types import (
     UnionRef,
     InputRef,
 )
-from hiku.scalar import Scalar
+from hiku.scalar import Scalar, scalar
 from hiku.graph import apply
 
 from hiku.federation.graph import FederatedNode, Graph
@@ -51,6 +51,7 @@ class Custom(FederationSchemaDirective):
     ...
 
 
+@scalar(specified_by_url="https://example.com/scalars/long")
 class Long(Scalar):
     @classmethod
     def parse(cls, value: Any) -> int:
@@ -198,7 +199,7 @@ expected_tmpl = """
     %s
     scalar Any
 
-    scalar Long
+    scalar Long @specifiedBy(url: "https://example.com/scalars/long")
 
     scalar _Any
 

--- a/tests/test_introspection_graphql.py
+++ b/tests/test_introspection_graphql.py
@@ -10,7 +10,7 @@ from hiku.enum import Enum
 from hiku.directives import Deprecated, Location, SchemaDirective, schema_directive
 from hiku.executors.sync import SyncExecutor
 from hiku.graph import Graph, Input, Interface, Root, Field, Node, Link, Union, apply, Option
-from hiku.scalar import Scalar
+from hiku.scalar import Scalar, scalar
 from hiku.schema import Schema
 from hiku.types import EnumRef, InterfaceRef, String, Integer, Sequence, TypeRef, Boolean, Float, Any, UnionRef, InputRef
 from hiku.types import Optional, Record
@@ -165,6 +165,10 @@ def _schema(types, directives: list[dict] | None = None, with_mutation=False):
               _directive(
                   'cached', ['FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'], [
                       _ival('ttl', _non_null(_INT), description=ANY)
+                  ]),
+              _directive(
+                  'specifiedBy', ['SCALAR'], [
+                      _ival('url', _non_null(_STR), description=ANY)
                   ]),
             ] + (directives or []),
             'mutationType': {'name': 'Mutation'} if with_mutation else None,
@@ -612,6 +616,9 @@ def test_query_enum_as_single_type(enum_name, expected):
 
 
 def test_custom_scalar():
+    @scalar(
+        specified_by_url='https://example.com/scalars/user-id',
+    )
     class UserId(Scalar):
         @classmethod
         def parse(cls, value: str) -> int:
@@ -660,6 +667,26 @@ def test_custom_scalar():
         ], ),
         _type('UserId', 'SCALAR'),
     ]) == introspect(graph)
+
+    query = """
+    query IntrospectionQuery {
+        customScalar: __type(name: "UserId") {
+            specifiedByURL
+        }
+        builtInScalar: __type(name: "String") {
+            specifiedByURL
+        }
+    }
+    """
+
+    assert execute(query, graph) == {
+        'customScalar': {
+            'specifiedByURL': 'https://example.com/scalars/user-id',
+        },
+        'builtInScalar': {
+            'specifiedByURL': None,
+        },
+    }
 
 
 def test_custom_int_scalar():

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -4,7 +4,7 @@ import pytest
 
 from hiku.executors.sync import SyncExecutor
 from hiku.graph import Field, Graph, Link, Node, Nothing, Option, Root
-from hiku.scalar import DateTime, Scalar
+from hiku.scalar import DateTime, Scalar, scalar
 from hiku.schema import Schema
 from hiku.types import Float, Integer, Optional, Sequence, TypeRef
 from hiku.utils import listify
@@ -16,6 +16,28 @@ from hiku.validate.query import validate
 def execute(graph, query):
     schema = Schema(SyncExecutor(), graph)
     return schema.execute_sync(query)
+
+
+def test_scalar_decorator_sets_metadata():
+    @scalar(
+        name="UserId",
+        description="User identifier.",
+        specified_by_url="https://example.com/user-id",
+    )
+    class CustomUserId(Scalar):
+        ...
+
+    assert CustomUserId.__type_name__ == "UserId"
+    assert CustomUserId.__description__ == "User identifier."
+    assert CustomUserId.__specified_by_url__ == "https://example.com/user-id"
+
+
+def test_undecorated_scalar_has_default_metadata():
+    class Undecorated(Scalar):
+        ...
+
+    assert Undecorated.__description__ is None
+    assert Undecorated.__specified_by_url__ is None
 
 
 class SomeType:


### PR DESCRIPTION
Implements the GraphQL [`@specifiedBy`](https://spec.graphql.org/draft/#sec--specifiedBy) directive for custom scalars.

## Changes

- **`@scalar` decorator** accepts a new `specified_by_url` parameter:
  ```python
  @scalar(specified_by_url="https://tools.ietf.org/html/rfc4122")
  class UUID(Scalar):
      ...
  ```
- **Introspection**: `__Type` gets the `specifiedByURL` field — returns the URL for custom scalars, `null` for everything else (per spec). Standard clients (GraphiQL, graphql-core's `get_introspection_query()`) request this field, so introspection now works with them out of the box.
- **`specifiedBy`** is registered as a built-in schema directive and listed in `__schema.directives`.
- **Federation SDL export** prints `scalar Long @specifiedBy(url: "...")`.

## Related fixes

- Custom scalar `description` (set via the `@scalar` decorator) was stored but never exposed in introspection — now it is.
- Undecorated `Scalar` subclasses had no `__description__` attribute at all; the metaclass now sets `None` defaults for `__description__` and `__specified_by_url__`.
- `__type(name: "String")` previously returned nothing for built-in scalars; they now resolve (they are members of `__schema.types`).

## Verification

- `uv run pytest tests` — 492 passed
- `uv run mypy hiku` — clean
- `uv run flake8` / `uv run black hiku --check` — clean